### PR TITLE
add flag to not turn bonds to metals into zobs

### DIFF
--- a/sketcherMinimizer.cpp
+++ b/sketcherMinimizer.cpp
@@ -172,11 +172,13 @@ void sketcherMinimizer::initialize(
         if (_bond->skip) {
             continue;
         }
-        if (_bond->bondOrder == 1 || _bond->bondOrder == 2) {
-            if (sketcherMinimizerAtom::isMetal(
-                    _bond->startAtom->atomicNumber) ||
-                sketcherMinimizerAtom::isMetal(_bond->endAtom->atomicNumber)) {
-                _bond->bondOrder = 0;
+        if (getTreatAllBondsToMetalAsZOBs()) {
+            if (_bond->bondOrder == 1 || _bond->bondOrder == 2) {
+                if (sketcherMinimizerAtom::isMetal(
+                                                   _bond->startAtom->atomicNumber) ||
+                    sketcherMinimizerAtom::isMetal(_bond->endAtom->atomicNumber)) {
+                    _bond->bondOrder = 0;
+                }
             }
         }
     }

--- a/sketcherMinimizer.h
+++ b/sketcherMinimizer.h
@@ -459,6 +459,14 @@ class EXPORT_COORDGEN sketcherMinimizer
     static void setTemplateFileDir(std::string dir);
     static void loadTemplates();
     static CoordgenTemplates m_templates;
+
+    bool getTreatAllBondsToMetalAsZOBs() {return m_treatAllBondsToMetalAsZOBs;}
+    void setTreatAllBondsToMetalAsZOBs(bool b) {m_treatAllBondsToMetalAsZOBs = b;}
+
+private:
+    /*all bonds to a metal atom are treated as if they were zero order bonds (this usually results
+     in a longer bond*/
+    bool m_treatAllBondsToMetalAsZOBs = true;
 };
 
 // EXPORT_COORDGEN sketcherMinimizerMolecule*

--- a/test/metalZob.mae
+++ b/test/metalZob.mae
@@ -1,0 +1,50 @@
+{ 
+ s_m_m2io_version
+ :::
+ 2.0.0 
+} 
+
+f_m_ct { 
+ s_m_title
+ s_m_entry_id
+ s_m_entry_name
+ i_m_ct_format
+ :::
+ Structure1 
+  1 
+  entry 
+  2
+ m_atom[6] { 
+  # First column is atom index #
+  i_m_mmod_type
+  r_m_x_coord
+  r_m_y_coord
+  r_m_z_coord
+  i_m_color
+  i_m_atomic_number
+  s_m_color_rgb
+  i_rdk_index
+  :::
+  1 158 0.000000 0.000000 0.000000 19 13 E11EE1  0
+  2 26 1.970000 0.000000 0.000000 43 7 5757FF  1
+  3 41 -0.801858 1.375985 -0.000000 21 1 FFFFFF  <>
+  4 41 -0.801888 -1.375976 -0.000019 21 1 FFFFFF  <>
+  5 43 2.307145 -0.952068 -0.000000 21 1 FFFFFF  <>
+  6 43 2.307145 0.477048 -0.823929 21 1 FFFFFF  <>
+  :::
+ } 
+ m_bond[5] { 
+  # First column is bond index #
+  i_m_from
+  i_m_to
+  i_m_order
+  :::
+  1 1 2 1
+  2 1 3 1
+  3 1 4 1
+  4 2 5 1
+  5 2 6 1
+  :::
+ } 
+} 
+

--- a/test/test_coordgen.cpp
+++ b/test/test_coordgen.cpp
@@ -179,3 +179,28 @@ BOOST_AUTO_TEST_CASE(ClearWedgesTest)
     BOOST_REQUIRE_EQUAL(mol->getBonds().at(2)->hasStereochemistryDisplay, false);
     BOOST_REQUIRE_EQUAL(mol->getBonds().at(3)->hasStereochemistryDisplay, true);
 }
+
+
+BOOST_AUTO_TEST_CASE(DisableMetalZOBs)
+{
+    // Load a molecule with a single bond to a metal. Make sure that disabling the automatic conversion
+    // to zob behaves as expected
+
+    const std::string testfile = (test_samples_path / "metalZobs.mae").string();
+
+    mae::Reader r(testfile);
+    auto block = r.next(mae::CT_BLOCK);
+    BOOST_REQUIRE(block != nullptr);
+
+    auto* mol = mol_from_mae_block(*block);
+    BOOST_REQUIRE(mol != nullptr);
+
+
+    sketcherMinimizer minimizer;
+    minimizer.setTreatAllBondsToMetalAsZOBs(false);
+    minimizer.initialize(mol); // minimizer takes ownership of mol
+    minimizer.runGenerateCoordinates();
+
+    auto indices = getReportingIndices(*mol);
+    BOOST_CHECK(areBondsNearIdeal(*mol, indices));
+}


### PR DESCRIPTION
added flag to not turn single and double bonds to metals into zobs.

added automated test to show the length of the bond is around the same as a single bond (zobs to metals usually are stretched out)